### PR TITLE
Enable fuzzy matching against applications in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Optional options (all inside one TV entry):
   - `sources` is an array of sources to display in HomeKit, default `["extInput:hdmi", "extInput:component", "extInput:scart", "extInput:cec", "extInput:widi"]`
   - `tvsource` is your preferred TV source, can be `tv:dvbt`, `tv:dvbc` or `tv:dvbs`, default none (no TV channels listed as inputs)
   - `applications` can be used to enable listing applications in the input list, default `false`
+  -- Providing an array of objects with application titles will only add applications whose names contain the titles to the input list:
+    ```
+    "applications": [
+                        {
+                            "title": "Netflix"
+                        },
+                        {
+                            "title": "Plex"
+                        },
+    ```
   - `soundoutput` is your preferred TV sound output, can be `speaker` or `headphone`, default `speaker`
   - `cookiepath` file (!) name to store the cookie file to, default `"[user home]/.homebridge/sonycookie"`
   - `port` is the IP port of your TV, default 80

--- a/index.js
+++ b/index.js
@@ -270,9 +270,12 @@ SonyTV.prototype.receiveApplications = function() {
       if (data.indexOf("error") < 0){
         var jayons = JSON.parse(data);
         var reslt = jayons.result[0];
-        reslt.forEach(function(source){
-          if (that.applications.length == 0 || that.applications.indexOf(source.title) >= 0) {
+        reslt.sort(source => source.title).forEach(function(source){
+          if (that.applications.length == 0 || that.applications.map(app => app.title).filter(title => source.title.includes(title)).length > 0) {
             that.addInputSource(source.title, source.uri, Characteristic.InputSourceType.APPLICATION);
+          }
+          else{
+            that.log("Ignoring application: " + source.title);
           }
         });
       }else{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bravia",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Homebridge plugin for Sony Bravia TVs (AndroidTV based ones and possibly others)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,

I setup my XBR-55X850C and found that a bunch of the builtin junk apps (as well as some other stuff that appears to be disabled) showed up in the list of available apps returned by the TV. There was some filtering in place in the application -> input initialization step, but it wasn't checking the correct property on the incoming data.

I also took the opportunity to sort the apps by title since the TV doesn't return them in alphabetical order.