### PR TITLE
Enhancements to allow user input for Model and Serial numbers

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -91,13 +91,13 @@
             },
             "model": {
               "title": "Model Name",
-              "description":"Customise the model name/number displayed in HomeBridge",
+              "description":"Customise the model name/number displayed in HomeKit",
               "type": "string",
               "required": false
             },
             "serial": {
               "title": "Serial Number",
-              "description":"Customise the serial number displayed in HomeBridge",
+              "description":"Customise the serial number displayed in HomeKit",
               "type": "string",
               "required": false
             }
@@ -131,7 +131,9 @@
         {
           "key":"tvs[].sources",
           "items":["tvs[].sources[]"]
-        }
+        },
+        "tvs[].model",
+        "tvs[].serial"
       ]
     }
   ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -88,6 +88,18 @@
             "items":{
               "title": "Source Name",
               "type": "string"
+            },
+            "model": {
+              "title": "Model Name",
+              "description":"Customise the model name/number displayed in HomeBridge",
+              "type": "string",
+              "required": false
+            },
+            "serial": {
+              "title": "Serial Number",
+              "description":"Customise the serial number displayed in HomeBridge",
+              "type": "string",
+              "required": false
             }
           }
         }

--- a/config.schema.json
+++ b/config.schema.json
@@ -91,13 +91,15 @@
             },
             "model": {
               "title": "Model Name",
-              "description":"Customise the model name/number displayed in HomeKit",
+              "description":"Customise the model name/number displayed in HomeKit. Defaults to Default-Model.",
+              "placeholder": "Sony Model Number eg. KDL32W600D",
               "type": "string",
               "required": false
             },
             "serial": {
               "title": "Serial Number",
-              "description":"Customise the serial number displayed in HomeKit",
+              "description":"Customise the serial number displayed in HomeKit. Defaults to Default-SerialNumber.",
+              "placeholder": "Serial Number",
               "type": "string",
               "required": false
             }

--- a/index.js
+++ b/index.js
@@ -160,11 +160,11 @@ SonyTV.prototype.createServices = function () {
   this.services.push(this.speakerService);
   var informationService = new Service.AccessoryInformation();
   informationService.setCharacteristic(Characteristic.Manufacturer, "Sony");	
-  if(config.model) {
-     informationService.setCharacteristic(Characteristic.Model, config.model);
+  if(this.model) {
+     informationService.setCharacteristic(Characteristic.Model, this.model);
   }
-  if(config.serial) {
-     informationService.setCharacteristic(Characteristic.Model, config.serial);
+  if(this.serial) {
+     informationService.setCharacteristic(Characteristic.Model, this.serial);
   }
   this.services.push(informationService);
   return this.services;

--- a/index.js
+++ b/index.js
@@ -159,10 +159,10 @@ SonyTV.prototype.createServices = function () {
   // TODO: information services
   //  var informationService = new Service.AccessoryInformation();
   //  informationService
-  //  .setCharacteristic(Characteristic.Manufacturer, "Sony")
-  //  .setCharacteristic(Characteristic.Model, "Android TV")
-  //  .setCharacteristic(Characteristic.SerialNumber, "12345");
-  //  this.services.push(informationService);
+	.setCharacteristic(Characteristic.Manufacturer, "Sony")
+  //  .setCharacteristic(Characteristic.Model, config.model)
+  //  .setCharacteristic(Characteristic.SerialNumber, config.serial);
+	this.services.push(informationService);
   return this.services;
 };
 

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ function SonyTV (platform, config, accessory = null) {
   this.starttimeout = config.starttimeout || 5000;
   this.comp = config.compatibilitymode;
   this.serverPort = config.serverPort || 8999;
-  this.model = config.model || 'Default-Model';
-  this.serial = config.serial || 'Default-SerialNumber';
+  this.model = config.model;// || 'Default-Model';
+  this.serial = config.serial;// || 'Default-SerialNumber';
   this.sources = config.sources || ['extInput:hdmi', 'extInput:component', 'extInput:scart', 'extInput:cec', 'extInput:widi'];
   this.useApps = (isNull(config.applications)) ? false : (config.applications instanceof Array == true ? config.applications.length > 0 : config.applications);
   this.applications = (isNull(config.applications) || (config.applications instanceof Array != true)) ? [] : config.applications;
@@ -158,13 +158,15 @@ SonyTV.prototype.createServices = function () {
   this.services.push(this.tvService);
   this.speakerService = new Service.TelevisionSpeaker();
   this.services.push(this.speakerService);
-  // TODO: information services
-    var informationService = new Service.AccessoryInformation();
-    informationService
-	.setCharacteristic(Characteristic.Manufacturer, "Sony")
-	.setCharacteristic(Characteristic.Model, config.model)
-	.setCharacteristic(Characteristic.SerialNumber, config.serial);
-	this.services.push(informationService);
+  var informationService = new Service.AccessoryInformation();
+  informationService.setCharacteristic(Characteristic.Manufacturer, "Sony");	
+  if(config.model) {
+     informationService.setCharacteristic(Characteristic.Model, config.model);
+  }
+  if(config.serial) {
+     informationService.setCharacteristic(Characteristic.Model, config.serial);
+  }
+  this.services.push(informationService);
   return this.services;
 };
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,8 @@ function SonyTV (platform, config, accessory = null) {
   this.starttimeout = config.starttimeout || 5000;
   this.comp = config.compatibilitymode;
   this.serverPort = config.serverPort || 8999;
+  this.model = config.model || 'Default-Model';
+  this.serial = config.serial || 'Default-SerialNumber';
   this.sources = config.sources || ['extInput:hdmi', 'extInput:component', 'extInput:scart', 'extInput:cec', 'extInput:widi'];
   this.useApps = (isNull(config.applications)) ? false : (config.applications instanceof Array == true ? config.applications.length > 0 : config.applications);
   this.applications = (isNull(config.applications) || (config.applications instanceof Array != true)) ? [] : config.applications;
@@ -157,11 +159,11 @@ SonyTV.prototype.createServices = function () {
   this.speakerService = new Service.TelevisionSpeaker();
   this.services.push(this.speakerService);
   // TODO: information services
-  //  var informationService = new Service.AccessoryInformation();
-  //  informationService
+    var informationService = new Service.AccessoryInformation();
+    informationService
 	.setCharacteristic(Characteristic.Manufacturer, "Sony")
-  //  .setCharacteristic(Characteristic.Model, config.model)
-  //  .setCharacteristic(Characteristic.SerialNumber, config.serial);
+	.setCharacteristic(Characteristic.Model, config.model)
+	.setCharacteristic(Characteristic.SerialNumber, config.serial);
 	this.services.push(informationService);
   return this.services;
 };

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function SonyTV (platform, config, accessory = null) {
     this.accessory = new Accessory(this.name, uuid);
     this.accessory.context.config = config;
     this.accessory.context.uuid = uuidv4();
-    this.log('New TV ' + this.name + ', will be queried for channels/apps and added to HomeKit');
+    this.log('New TV ' + this.name + '(Sony: ' + this.model + '), will be queried for channels/apps and added to HomeKit');
     this.createServices();
     this.applyCallbacks();
   }


### PR DESCRIPTION
Hello,
I raised a suggestion to include the ability to customise the model and serial number exposed to HomeKit. #103

I have made the form input optional and any non input to default to Homebridge's default values of Default-Model and Default-SerialNumber.

I have forced the Manufacturer detail to be 'Sony', as this plugin is specifically designed for Sony TV.