### PR TITLE
Homebridge 2.0 Compatibility Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the change log for the plugin, all relevant changes will be listed here.
 For documentation please see the [README](https://github.com/normen/homebridge-bravia/blob/master/README.md)
 
 ## 2.4.10
-- Fixes to index.js and package.json to meet Homebridge 2.0 readiness
+- Fixes to index.js to meet Homebridge 2.0 readiness
 - index.js changes to avoid issues adding previously cached accessories
 - pacakge.json - config updates to support homebridge 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ This is the change log for the plugin, all relevant changes will be listed here.
 
 For documentation please see the [README](https://github.com/normen/homebridge-bravia/blob/master/README.md)
 
+## 2.4.10
+- Fixes to index.js and package.json to meet Homebridge 2.0 readiness
+- index.js changes to avoid issues adding previously cached accessories
+- pacakge.json - config updates to support homebridge 2.0
+
 ## 2.4.9
 - Use proper storage folder `plugin-persist/homebridge-bravia`
 

--- a/index.js
+++ b/index.js
@@ -49,8 +49,7 @@ class BraviaPlatform {
     } else {
       this.log('Restoring ' + accessory.displayName + ' from HomeKit');
       // TODO: reachable
-      accessory.reachable = true;
-      // if its restored its registered
+            // if its restored its registered
       self.devices.push(new SonyTV(this, existingConfig, accessory));
       accessory.context.isRegisteredInHomeKit = true;
     }
@@ -380,7 +379,7 @@ class SonyTV {
         changeDone = true;
       }
     });
-    if (!this.accessory.context.isRegisteredInHomeKit) {
+    if (!this.accessory.context.isexternal) {
       // add base services that haven't been added yet
       this.services.forEach(service => {
         try {
@@ -395,8 +394,7 @@ class SonyTV {
         }
       });
       this.log('Registering HomeBridge Accessory for ' + this.name);
-      this.accessory.context.isRegisteredInHomeKit = true;
-      if (!this.accessory.context.isexternal) {
+            if (!this.accessory.context.isexternal) {
         this.platform.api.registerPlatformAccessories('homebridge-bravia', 'BraviaPlatform', [this.accessory]);
       } else {
         try {
@@ -1123,5 +1121,6 @@ module.exports = function (homebridge) {
   Characteristic = homebridge.hap.Characteristic;
   UUIDGen = homebridge.hap.uuid;
   STORAGE_PATH = updateStorage(homebridge.user.storagePath());
+  // Dynamic registration is already compliant with Homebridge v2.x
   homebridge.registerPlatform('homebridge-bravia', 'BraviaPlatform', BraviaPlatform, true);
 };

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class BraviaPlatform {
       // TODO: reachable
             // if its restored its registered
       self.devices.push(new SonyTV(this, existingConfig, accessory));
-      accessory.context.isRegisteredInHomeKit = true;
+     // accessory.context.isRegisteredInHomeKit = true;
     }
   }
 }
@@ -379,40 +379,44 @@ class SonyTV {
         changeDone = true;
       }
     });
-    if (!this.accessory.context.isexternal) {
-      // add base services that haven't been added yet
-      this.services.forEach(service => {
-        try {
-          if (!self.accessory.services.includes(service)) {
-            self.log('Adding base service to accessory');
-            self.accessory.addService(service);
-            changeDone = true;
-          }
-        } catch (e) {
-          self.log('Can\'t add service!');
-          self.log(e);
-        }
-      });
-      this.log('Registering HomeBridge Accessory for ' + this.name);
-            if (!this.accessory.context.isexternal) {
-        this.platform.api.registerPlatformAccessories('homebridge-bravia', 'BraviaPlatform', [this.accessory]);
-      } else {
-        try {
-          const data = JSON.stringify(this.accessory.context);
-          fs.writeFileSync(STORAGE_PATH + '/sonytv-context-' + this.accessory.context.config.name + '.json', data);
-        } catch (e) {
-          this.log(e);
-        }
-        this.platform.api.publishExternalAccessories('homebridge-bravia', [this.accessory]);
+  if (!this.accessory._associatedHAPAccessory && !this.accessory.context.isexternal) {
+  // Add base services if not yet added
+  this.services.forEach(service => {
+    try {
+      if (!this.accessory.services.includes(service)) {
+        this.log('Adding base service to accessory');
+        this.accessory.addService(service);
+        changeDone = true;
       }
-    } else if (changeDone) {
-      this.log('Updating HomeBridge Accessory for ' + this.name);
-      this.platform.api.updatePlatformAccessories([this.accessory]);
+    } catch (e) {
+      this.log('Can\'t add service!');
+      this.log(e);
     }
-    if (this.accessory.context.isexternal) {
-      this.saveChannelsToFile();
-    }
-    this.receivingSources = false;
+  });
+
+  this.log('Registering HomeBridge Accessory for ' + this.name);
+  this.platform.api.registerPlatformAccessories('homebridge-bravia', 'BraviaPlatform', [this.accessory]);
+
+} else if (this.accessory.context.isexternal) {
+  try {
+    const data = JSON.stringify(this.accessory.context);
+    fs.writeFileSync(STORAGE_PATH + '/sonytv-context-' + this.accessory.context.config.name + '.json', data);
+  } catch (e) {
+    this.log(e);
+  }
+  this.platform.api.publishExternalAccessories('homebridge-bravia', [this.accessory]);
+
+} else if (changeDone) {
+  this.log('Updating HomeBridge Accessory for ' + this.name);
+  this.platform.api.updatePlatformAccessories([this.accessory]);
+}
+
+if (this.accessory.context.isexternal) {
+  this.saveChannelsToFile();
+}
+
+this.receivingSources = false;
+   
   }
   // initialize a scan for new sources
   receiveSources(checkPower = null) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "keywords": [
     "homebridge-plugin",
     "sony",
+    "bravia",
     "androidtv",
     "tv",
     "homebridge"
@@ -24,14 +25,13 @@
   },
   "homepage": "https://github.com/normen/homebridge-bravia#readme",
   "engines": {
-    "homebridge": ">=0.4.46",
-    "node": ">=0.12.0"
+    "homebridge": ">1.6.0 || ^2.0.0",
+    "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
   },
+  "displayName": "Homebridge Bravia",
+  "pluginAlias": "BraviaPlatform",
   "dependencies": {
     "base-64": "^0.1.0",
     "wake_on_lan": "^1.0.0"
-  },
-  "devDependencies": {
-    "homebridge": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-bravia",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Homebridge plugin for Sony Bravia TVs (AndroidTV based ones and possibly others)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request adds support for Homebridge 2.0 and resolves a compatibility issue with Homebridge 2.0 where previously restored accessories caused a crash due to duplicate registration.

- Adds _associatedHAPAccessory check before registration
- Retains external accessory publishing logic
- Tested on Homebridge 1.9 and 2.0 pre-release

- Closes #183 

Looking forward to your feedback!